### PR TITLE
Call the connect handler before any message handler

### DIFF
--- a/melody.go
+++ b/melody.go
@@ -88,7 +88,7 @@ func (m *Melody) HandleRequest(w http.ResponseWriter, r *http.Request) {
 
 	m.hub.register <- session
 
-	go m.connectHandler(session)
+	m.connectHandler(session)
 
 	go session.writePump()
 


### PR DESCRIPTION
When running a benchmark with `GOMAXPROCS=24`, message handling code would panic because the session was not properly initialised. This was because the connect handler was not called before the message handler.
